### PR TITLE
Pull source as git submodules by default

### DIFF
--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -162,10 +162,14 @@ module Deps = struct
 end
 
 module Config = struct
+
+  type pull_mode = Submodules | Source [@@deriving sexp]
+
   type t = {
     root_packages : Types.Opam.package list;
     excludes : Types.Opam.package list;
     pins : Types.Opam.pin list;
+    pull_mode: pull_mode [@default Submodules];
     opam_repo : Uri_sexp.t;
         [@default Uri.of_string Config.duniverse_opam_repo] [@sexp_drop_default.sexp]
     remotes : string list; [@default []]

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -82,10 +82,14 @@ module Deps : sig
 end
 
 module Config : sig
+
+  type pull_mode = Submodules | Source [@@deriving sexp]
+
   type t = {
     root_packages : Types.Opam.package list;
     excludes : Types.Opam.package list;
     pins : Types.Opam.pin list;
+    pull_mode: pull_mode [@default Submodules];
     opam_repo : Uri_sexp.t;
     remotes : string list; [@default []]
     branch : string; [@default "master"]

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -138,6 +138,15 @@ let git_fetch_to ~repo ~remote_name ~ref ~branch ?(force = false) () =
   run_git ~repo Cmd.(v "fetch" % remote_name % ref) >>= fun () ->
   run_git ~repo Cmd.(v "branch" %% on force (v "-f") % branch % "FETCH_HEAD")
 
+let git_submodule_add ~repo ~remote_name ~ref ~branch ~target_path ?(force = false) () =
+  run_git ~repo Cmd.(v "submodule" % "add" %% on force (v "-f") % "-b" %
+    branch % "--name" % remote_name % "--" % ref % target_path)
+
+let git_update_index ~repo ?(add=false) ~cacheinfo () =
+  let mode, hash, path = cacheinfo in
+  run_git ~repo Cmd.(v "update-index" %% on add (v "--add") %
+    "--cacheinfo" % (string_of_int mode) % hash % p path)
+
 let git_init_bare ~repo = run_and_log Cmd.(v "git" % "init" % "--bare" % p repo)
 
 let git_clone ~branch ~remote ~output_dir =

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -60,6 +60,18 @@ val git_resolve : remote:string -> ref:Git.Ref.t -> (Git.Ref.resolved, Rresult.R
 val git_branch :
   repo:Fpath.t -> ref:Git.Ref.t -> branch_name:string -> (unit, [> Rresult.R.msg ]) result
 
+val git_submodule_add :
+  repo:Fpath.t -> remote_name:string ->  ref:Git.Ref.t -> branch:string ->
+  target_path:string -> ?force:bool -> unit -> (unit, [> Rresult.R.msg ]) result
+(** [git_submodule_add] will run [git submodule] for [remote_name] and initialise
+   it into [target_path] for commit [ref] and on the remote [branch]. *)
+
+val git_update_index :
+  repo:Fpath.t -> ?add:bool -> cacheinfo:int * string * Fpath.t ->
+  unit -> (unit, [> Rresult.R.msg ]) result
+(** [git_update_index] will add the [cacheinfo] (a tuple of mode, hash and target path)
+  to the index, and append it to the cache if [add] is [true]. *)
+
 val run_opam_package_deps : root:Fpath.t -> string list -> (string list, [> Rresult.R.msg ]) result
 (** [run_opam_packages_deps ~root packages] returns a list of versioned constrained packages that
     resolves the transitive dependencies of [packages]. *)


### PR DESCRIPTION
`duniverse pull` will now clone the source code and add each of
the vendored packages as a git submodule. It does this by adding
the submodule commit objects after the source pulls have been done.
This is a lot faster than the default `git submodule add` which
requires setting up remote tracking branches for each of the
remotes.

This adds a `--no-submodules` option to `pull` to just do a
source code clone.