### PR TITLE
Upgrade ocamlformat

### DIFF
--- a/.ocamlformat
+++ b/.ocamlformat
@@ -1,3 +1,3 @@
-version=0.12
+version=0.13.0
 profile=conventional
 margin=100

--- a/cli/init.ml
+++ b/cli/init.ml
@@ -1,8 +1,8 @@
 open Duniverse_lib
 open Duniverse_lib.Types
 
-let build_config ~local_packages ~branch ~explicit_root_packages ~pull_mode ~excludes ~pins ~remotes ~opam_repo
-    =
+let build_config ~local_packages ~branch ~explicit_root_packages ~pull_mode ~excludes ~pins ~remotes
+    ~opam_repo =
   let open Rresult.R.Infix in
   Opam_cmd.choose_root_packages ~explicit_root_packages ~local_packages >>= fun root_packages ->
   let root_packages =
@@ -34,12 +34,14 @@ let resolve_ref deps =
   Duniverse.Deps.resolve ~resolve_ref deps
 
 let run (`Repo repo) (`Branch branch) (`Explicit_root_packages explicit_root_packages)
-    (`Excludes excludes) (`Pins pins) (`Opam_repo opam_repo) (`Remotes remotes) (`Pull_mode pull_mode) () =
+    (`Excludes excludes) (`Pins pins) (`Opam_repo opam_repo) (`Remotes remotes)
+    (`Pull_mode pull_mode) () =
   let open Rresult.R.Infix in
   let opam_repo = Uri.of_string opam_repo in
   Common.Logs.app (fun l -> l "Calculating Duniverse on the %a branch" Styled_pp.branch branch);
   Opam_cmd.find_local_opam_packages repo >>= fun local_packages ->
-  build_config ~local_packages ~branch ~explicit_root_packages ~pull_mode ~excludes ~pins ~remotes ~opam_repo
+  build_config ~local_packages ~branch ~explicit_root_packages ~pull_mode ~excludes ~pins ~remotes
+    ~opam_repo
   >>= fun config ->
   Common.Logs.app (fun l -> l "Initializing temporary opam switch");
   init_tmp_opam ~local_packages ~config >>= fun root ->
@@ -101,12 +103,18 @@ let opam_repo =
 
 let pull_mode =
   let doc =
-    "How to pull the sources. If $(i,submodules) (the default), the pull command will initialise them \
-     as git submodules.  If $(i,source) then the source code will directly be cloned to the source tree."
+    "How to pull the sources. If $(i,submodules) (the default), the pull command will initialise \
+     them as git submodules.  If $(i,source) then the source code will directly be cloned to the \
+     source tree."
   in
-  Common.Arg.named (fun x -> `Pull_mode x)
-  Arg.(
-    value & opt (enum ["submodule",Duniverse.Config.Submodules;"source", Duniverse.Config.Source]) Duniverse.Config.Submodules & info ["pull-mode"] ~docv:"PULL_MODE" ~doc)
+  Common.Arg.named
+    (fun x -> `Pull_mode x)
+    Arg.(
+      value
+      & opt
+          (enum [ ("submodule", Duniverse.Config.Submodules); ("source", Duniverse.Config.Source) ])
+          Duniverse.Config.Submodules
+      & info [ "pull-mode" ] ~docv:"PULL_MODE" ~doc)
 
 let pins =
   let open Types.Opam in

--- a/lib/dune
+++ b/lib/dune
@@ -1,6 +1,6 @@
 (library
  (name duniverse_lib)
- (libraries dune-private-libs.stdune bos fmt threads logs
-   opam-core opam-file-format rresult sexplib uri uri-sexp)
+ (libraries dune-private-libs.stdune bos fmt threads logs opam-core
+   opam-file-format rresult sexplib uri uri-sexp)
  (preprocess
   (pps ppx_sexp_conv)))

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -162,14 +162,13 @@ module Deps = struct
 end
 
 module Config = struct
-
   type pull_mode = Submodules | Source [@@deriving sexp]
 
   type t = {
     root_packages : Types.Opam.package list;
     excludes : Types.Opam.package list;
     pins : Types.Opam.pin list;
-    pull_mode: pull_mode [@default Submodules];
+    pull_mode : pull_mode; [@default Submodules]
     opam_repo : Uri_sexp.t;
         [@default Uri.of_string Config.duniverse_opam_repo] [@sexp_drop_default.sexp]
     remotes : string list; [@default []]

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -82,14 +82,13 @@ module Deps : sig
 end
 
 module Config : sig
-
   type pull_mode = Submodules | Source [@@deriving sexp]
 
   type t = {
     root_packages : Types.Opam.package list;
     excludes : Types.Opam.package list;
     pins : Types.Opam.pin list;
-    pull_mode: pull_mode [@default Submodules];
+    pull_mode : pull_mode; [@default Submodules]
     opam_repo : Uri_sexp.t;
     remotes : string list; [@default []]
     branch : string; [@default "master"]

--- a/lib/exec.ml
+++ b/lib/exec.ml
@@ -139,13 +139,17 @@ let git_fetch_to ~repo ~remote_name ~ref ~branch ?(force = false) () =
   run_git ~repo Cmd.(v "branch" %% on force (v "-f") % branch % "FETCH_HEAD")
 
 let git_submodule_add ~repo ~remote_name ~ref ~branch ~target_path ?(force = false) () =
-  run_git ~repo Cmd.(v "submodule" % "add" %% on force (v "-f") % "-b" %
-    branch % "--name" % remote_name % "--" % ref % target_path)
+  run_git ~repo
+    Cmd.(
+      v "submodule" % "add"
+      %% on force (v "-f")
+      % "-b" % branch % "--name" % remote_name % "--" % ref % target_path)
 
-let git_update_index ~repo ?(add=false) ~cacheinfo () =
+let git_update_index ~repo ?(add = false) ~cacheinfo () =
   let mode, hash, path = cacheinfo in
-  run_git ~repo Cmd.(v "update-index" %% on add (v "--add") %
-    "--cacheinfo" % (string_of_int mode) % hash % p path)
+  run_git ~repo
+    Cmd.(
+      v "update-index" %% on add (v "--add") % "--cacheinfo" % string_of_int mode % hash % p path)
 
 let git_init_bare ~repo = run_and_log Cmd.(v "git" % "init" % "--bare" % p repo)
 

--- a/lib/exec.mli
+++ b/lib/exec.mli
@@ -61,14 +61,23 @@ val git_branch :
   repo:Fpath.t -> ref:Git.Ref.t -> branch_name:string -> (unit, [> Rresult.R.msg ]) result
 
 val git_submodule_add :
-  repo:Fpath.t -> remote_name:string ->  ref:Git.Ref.t -> branch:string ->
-  target_path:string -> ?force:bool -> unit -> (unit, [> Rresult.R.msg ]) result
+  repo:Fpath.t ->
+  remote_name:string ->
+  ref:Git.Ref.t ->
+  branch:string ->
+  target_path:string ->
+  ?force:bool ->
+  unit ->
+  (unit, [> Rresult.R.msg ]) result
 (** [git_submodule_add] will run [git submodule] for [remote_name] and initialise
    it into [target_path] for commit [ref] and on the remote [branch]. *)
 
 val git_update_index :
-  repo:Fpath.t -> ?add:bool -> cacheinfo:int * string * Fpath.t ->
-  unit -> (unit, [> Rresult.R.msg ]) result
+  repo:Fpath.t ->
+  ?add:bool ->
+  cacheinfo:int * string * Fpath.t ->
+  unit ->
+  (unit, [> Rresult.R.msg ]) result
 (** [git_update_index] will add the [cacheinfo] (a tuple of mode, hash and target path)
   to the index, and append it to the cache if [add] is [true]. *)
 


### PR DESCRIPTION
The first commit is reformatting using 0.12 (was not formatted, [ocaml-ci](https://ci.ocamllabs.io/github/ocamllabs/duniverse/commit/08500e3b/variant/lint)).
The upgrade creates no diff.