### PR TITLE
Add pin management to duniverse

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,16 @@ COMMANDS
        opam-install
            install packages that are not duniverse-compatible via opam
 
+       pin Add a pinned package dependency to dune-get
+
        print-ocaml-compilers
            print OCaml compilers that are supported for this duniverse
 
        pull
            fetch the latest archives of the vendored libraries
+
+       unpin
+           Remove a pinned package dependency from dune-get
 
        update
            update the commit hash corresponding to the tracked branch/tag for

--- a/bin/duniverse.ml
+++ b/bin/duniverse.ml
@@ -17,6 +17,7 @@
 open Duniverse_cli
 
 let cmds =
-  [ Init.cmd; Update.cmd; Pull.cmd; Opam_install.cmd; Depext.cmd; Print_ocaml_compilers.cmd ]
+  [ Init.cmd; Pin.pin_cmd; Pin.unpin_cmd; Update.cmd; Pull.cmd; Opam_install.cmd;
+    Depext.cmd; Print_ocaml_compilers.cmd ]
 
 let () = Cmdliner.Term.(exit @@ eval_choice Default.cmd cmds)

--- a/cli/common.ml
+++ b/cli/common.ml
@@ -1,5 +1,4 @@
 module Ffmt = Fmt
-open Stdune
 open Duniverse_lib
 
 module Arg = struct
@@ -39,6 +38,17 @@ module Arg = struct
         windows_only priority extra_path
     in
     Cmdliner.Term.env_info ~doc var
+
+  let dev_repo =
+    let parse s =
+      match Opam.Dev_repo.from_string s with
+      | { vcs = Some Git; uri = dev_repo_uri } ->
+          (match Uri.host dev_repo_uri with
+          | Some _host -> Ok dev_repo_uri
+          | None -> Error (`Msg "dev-repo without host"))
+      | { vcs = None | Some (Other _); _ } -> Error (`Msg "dev-repo doesn't use git as a VCS") in
+    Cmdliner.Arg.conv ~docv:"DEV_REPO" (parse, Uri.pp_hum)
+
 
   let caches =
     let duniverse_cache =
@@ -90,6 +100,7 @@ end
 
 (** Filters the duniverse according to the CLI provided list of repos *)
 let filter_duniverse ~to_consider (src_deps : _ Duniverse.Deps.Source.t list) =
+  let open Stdune in
   let open Rresult in
   match to_consider with
   | None -> Ok src_deps

--- a/cli/common.mli
+++ b/cli/common.mli
@@ -26,6 +26,9 @@ module Arg : sig
   (** CLI arguments consisting of the list of source deps repo to process. If [None],
       the whole duniverse should be processed. If [Some l] then [l] is non empty. *)
 
+  val dev_repo : Uri.t Cmdliner.Arg.converter
+  (** Cache selection environment variables for use in terms. *)
+
   val caches : Cmdliner.Term.env_info list
   (** Cache selection environment variables for use in terms. *)
 

--- a/cli/init.ml
+++ b/cli/init.ml
@@ -23,87 +23,9 @@ let compute_deps ~opam_entries =
   let get_default_branch remote = Exec.git_default_branch ~remote () in
   Duniverse.Deps.from_opam_entries ~get_default_branch opam_entries
 
-let compute_depexts ~get_opam_path pkgs =
-  let open Rresult.R in
-  Exec.map (Opam_cmd.get_opam_depexts ~get_opam_path) pkgs >>| fun depexts ->
-  List.flatten depexts |> List.sort_uniq Stdlib.compare
-
 let resolve_ref deps =
   let resolve_ref ~upstream ~ref = Exec.git_resolve ~remote:upstream ~ref in
   Duniverse.Deps.resolve ~resolve_ref deps
-
-module Pins = struct
-  open Rresult.R
-
-  let name pin =
-    pin.Types.Opam.pin
-
-  let path pin =
-    Fpath.(Config.pins_dir / (pin.Types.Opam.pin ^ ".opam"))
-
-  let read_from_config duniverse_file =
-    Bos.OS.File.exists duniverse_file >>= fun exists ->
-    if not exists then Ok [] else
-    Duniverse.load ~file:duniverse_file >>= fun duniverse ->
-    Ok duniverse.config.pins
-
-  let to_package (pin : Types.Opam.pin) : Types.Opam.package =
-    let name = pin.pin in
-    let version = None in
-    {name; version}
-
-  let to_opam_entry (pin : Types.Opam.pin) : Types.Opam.entry =
-    let name = pin.pin in
-    let package = to_package pin in
-    let dev_repo = Opam_cmd.classify_from_dev_repo ~name pin.url in
-    { package; dev_repo; tag = pin.tag; is_dune = true }
-
-  let copy_opam_files ~pinned_paths deps =
-    Bos.OS.Dir.create Config.pins_dir >>= fun _created ->
-    Stdune.Result.List.iter deps
-      ~f:(fun {Duniverse.Deps.Source.dir; provided_packages; _} ->
-        Stdune.Result.List.iter provided_packages
-          ~f:(fun {Duniverse.Deps.Opam.name; _} ->
-            if String.Map.mem name pinned_paths then Ok () else
-            let opam = name ^ ".opam" in
-            let src = Fpath.(Config.vendor_dir / dir / opam |> to_string) in
-            let dst = Fpath.(Config.pins_dir / opam |> to_string) in
-            let cmd = Bos.Cmd.(v "cp" % src % dst) in (* FIXME: does this work on win? *)
-            Bos.OS.Cmd.run cmd))
-
-  let remove_stale_pins ~pinned_paths pins =
-    if pins = [] then Bos.OS.Dir.delete ~recurse:true Config.pins_dir else
-    let stale =
-      String.Map.filter
-        (fun name _ -> not (List.exists (fun pin -> pin.Types.Opam.pin = name) pins))
-        pinned_paths in
-    String.Map.fold (fun _ p _ -> Bos.OS.File.delete ~must_exist:true p) stale (Ok ())
-
-  let pull ~pull_mode ~repo ~pinned_paths pins =
-    let opam_entries = List.map to_opam_entry pins in
-    compute_deps ~opam_entries >>= resolve_ref >>= fun {Duniverse.Deps.duniverse; _} ->
-    let duniverse_to_pull =
-      List.filter (fun {Duniverse.Deps.Source.provided_packages; _} ->
-          List.for_all (fun {Duniverse.Deps.Opam.name; _} -> not (String.Map.mem name pinned_paths))
-            provided_packages)
-        duniverse in
-    Cloner.get_cache () >>= fun cache ->
-    Pull.duniverse ~cache ~pull_mode ~repo duniverse_to_pull >>= fun () ->
-    Ok duniverse
-
-  let init ~repo ~pull_mode ~pins =
-    if pins <> [] then
-      Common.Logs.app (fun l -> l "Using %a pins from %a: %a."
-          Fmt.(styled `Green int) (List.length pins)
-          Styled_pp.path (Fpath.normalize Config.duniverse_file)
-          Fmt.(list ~sep:(unit " ") (styled `Yellow string))
-          (List.map name pins));
-    Opam_cmd.find_local_opam_packages Config.pins_dir >>= fun pinned_paths ->
-    remove_stale_pins ~pinned_paths pins >>= fun () ->
-    pull ~pull_mode ~repo ~pinned_paths pins >>= fun src_deps ->
-    copy_opam_files ~pinned_paths src_deps >>= fun () ->
-    Ok src_deps
-end
 
 let run (`Repo repo)
     (`Opam_repo opam_repo) (`Pull_mode pull_mode) () =
@@ -119,9 +41,15 @@ let run (`Repo repo)
   let local_packages = List.map fst (String.Map.bindings local_paths) in
   build_config ~local_packages ~pins ~pull_mode ~opam_repo
   >>= fun config ->
+  if pins <> [] then
+    Common.Logs.app (fun l -> l "Using %a pins from %a: %a."
+        Fmt.(styled `Green int) (List.length pins)
+        Styled_pp.path (Fpath.normalize Config.duniverse_file)
+        Fmt.(list ~sep:(unit " ") (styled `Yellow string))
+        (List.map (fun pin -> pin.Types.Opam.pin) pins));
   Pins.init ~repo ~pull_mode ~pins >>= fun pin_deps ->
   let opam_paths =
-    List.fold_left (fun acc pin -> String.Map.add (Pins.name pin) (Pins.path pin) acc)
+    List.fold_left (fun acc pin -> String.Map.add (pin.Types.Opam.pin) (Pins.path pin) acc)
       local_paths pins in
   let get_opam_path {Types.Opam.name; version} =
     match String.Map.find name opam_paths with
@@ -133,7 +61,7 @@ let run (`Repo repo)
   let packages = config.root_packages @ List.map Pins.to_package pins in
   Opam_cmd.calculate_opam ~packages ~get_opam_path ~local_opam_repo >>= fun opam_entries ->
   Opam_cmd.report_packages_stats opam_entries;
-  compute_depexts ~get_opam_path (List.map (fun entry -> entry.Types.Opam.package) opam_entries)
+  Opam_cmd.compute_depexts ~get_opam_path (List.map (fun entry -> entry.Types.Opam.package) opam_entries)
   >>= fun depexts ->
   Common.Logs.app (fun l ->
       l "Recording %a depext formulae for %a packages."

--- a/cli/init.ml
+++ b/cli/init.ml
@@ -72,6 +72,7 @@ module Pins = struct
             Bos.OS.Cmd.run cmd))
 
   let remove_stale_pins ~pinned_paths pins =
+    if pins = [] then Bos.OS.Dir.delete ~recurse:true Config.pins_dir else
     let stale =
       String.Map.filter
         (fun name _ -> not (List.exists (fun pin -> pin.Types.Opam.pin = name) pins))
@@ -91,11 +92,12 @@ module Pins = struct
     Ok duniverse
 
   let init ~repo ~pull_mode ~pins =
-    Common.Logs.app (fun l -> l "Using %a pins from %a: %a."
-        Fmt.(styled `Green int) (List.length pins)
-        Styled_pp.path (Fpath.normalize Config.duniverse_file)
-        Fmt.(list ~sep:(unit " ") (styled `Yellow string))
-        (List.map name pins));
+    if pins <> [] then
+      Common.Logs.app (fun l -> l "Using %a pins from %a: %a."
+          Fmt.(styled `Green int) (List.length pins)
+          Styled_pp.path (Fpath.normalize Config.duniverse_file)
+          Fmt.(list ~sep:(unit " ") (styled `Yellow string))
+          (List.map name pins));
     Opam_cmd.find_local_opam_packages Config.pins_dir >>= fun pinned_paths ->
     remove_stale_pins ~pinned_paths pins >>= fun () ->
     pull ~pull_mode ~repo ~pinned_paths pins >>= fun src_deps ->

--- a/cli/pin.ml
+++ b/cli/pin.ml
@@ -47,6 +47,7 @@ let unpin (`Pin_name to_remove) (`Repo repo) () =
       let config = { duniverse.config with pins = filtered } in
       let duniverse = { duniverse with config } in
       Duniverse.save ~file duniverse >>= fun () ->
+      Bos.OS.File.delete Fpath.(Config.pins_dir / (to_remove ^ ".opam")) >>= fun () ->
       Common.Logs.app (fun l ->
           l "Removed pin %a from %a. You can now run %a to update the dependencies."
             Fmt.(styled `Yellow string) to_remove

--- a/cli/pin.ml
+++ b/cli/pin.ml
@@ -1,0 +1,99 @@
+open Duniverse_lib
+open Rresult
+
+
+let pin (`Pin_name pin_name) (`Pin_uri uri) (`Repo repo) () =
+  let duniverse_file = Fpath.(repo // Config.duniverse_file) in
+  Bos.OS.File.exists duniverse_file >>= fun exists ->
+  if not exists then
+    Rresult.R.error_msgf
+      "No %a file found, please run `duniverse init` before adding pins."
+      Fpath.pp duniverse_file
+  else
+    let tag = Uri.fragment uri in
+    let uri = Uri.with_fragment uri None in
+    let pin = { Types.Opam.pin = pin_name; url = Some (Uri.to_string uri); tag } in
+    Duniverse.load ~file:duniverse_file >>= fun duniverse ->
+    let config = { duniverse.config with pins = pin :: duniverse.config.pins } in
+    let duniverse = { duniverse with config } in
+    let file = Fpath.(repo // Config.duniverse_file) in
+    Duniverse.save ~file duniverse >>= fun () ->
+    Common.Logs.app (fun l ->
+        l "Added pin %a to %a. You can now run %a to update the dependencies."
+          Fmt.(styled `Yellow string) pin_name
+          Styled_pp.path (Fpath.normalize file)
+          Fmt.(styled `Blue string)
+          "duniverse init");
+    Ok ()
+
+
+let unpin (`Pin_name to_remove) (`Repo repo) () =
+  let file = Fpath.(repo // Config.duniverse_file) in
+  Bos.OS.File.exists file >>= fun exists ->
+  if not exists then
+    Rresult.R.error_msgf
+      "No %a file found, please run `duniverse init` before removing with pins."
+      Fpath.pp file
+  else
+    Duniverse.load ~file >>= fun duniverse ->
+    let pins_len = List.length duniverse.config.pins in
+    let filtered = List.filter (fun pin -> pin.Types.Opam.pin <> to_remove) duniverse.config.pins in
+    if pins_len = List.length filtered then
+      R.error_msgf "Could not find pin %s in %a." to_remove Fpath.pp (Fpath.normalize file)
+    else
+      let config = { duniverse.config with pins = filtered } in
+      let duniverse = { duniverse with config } in
+      Duniverse.save ~file duniverse >>= fun () ->
+      Common.Logs.app (fun l ->
+          l "Removed pin %a from %a. You can now run %a to update the dependencies."
+            Fmt.(styled `Yellow string) to_remove
+            Styled_pp.path (Fpath.normalize file)
+            Fmt.(styled `Blue string)
+            "duniverse init");
+      Ok ()
+
+
+open Cmdliner
+
+let pin_name =
+  let docv = "PACKAGE_NAME" in
+  let doc = "The $(docv) to be added to the " ^ Fpath.to_string Config.duniverse_file ^ " file." in
+  Common.Arg.named
+    (fun x -> `Pin_name x)
+    Arg.(required & pos 0 (some string) None & info [] ~docv ~doc)
+
+let dev_repo =
+  let docv = "REPO_URI" in
+  let doc = "The $(docv) used to pull the source code of the package to be pinned." in
+  Common.Arg.named
+    (fun x -> `Pin_uri x)
+    Arg.(required & pos 1 (some Common.Arg.dev_repo) None & info [] ~docv ~doc)
+
+let pin_cmd =
+  let term =
+    let open Term in
+    term_result
+      ( const pin $ pin_name $ dev_repo $ Common.Arg.repo $ Common.Arg.setup_logs () ) in
+  let info =
+    let exits = Term.default_exits in
+    let doc =
+      Fmt.strf "Add a pinned package dependency to $(b,%a)" Fpath.pp Config.duniverse_file
+    in
+    let man = [] in
+    Term.info "pin" ~doc ~exits ~man ~envs:Common.Arg.caches in
+  (term, info)
+
+let unpin_cmd =
+  let term =
+    let open Term in
+    term_result
+      ( const unpin $ pin_name $ Common.Arg.repo $ Common.Arg.setup_logs () ) in
+  let info =
+    let exits = Term.default_exits in
+    let doc =
+      Fmt.strf "Remove a pinned package dependency from $(b,%a)" Fpath.pp Config.duniverse_file
+    in
+    let man = [] in
+    Term.info "unpin" ~doc ~exits ~man ~envs:Common.Arg.caches in
+  (term, info)
+

--- a/cli/pull.ml
+++ b/cli/pull.ml
@@ -55,92 +55,6 @@ let check_dune_lang_version ~yes ~repo =
     Logs.debug (fun l -> l "No dune-project found");
     Ok () )
 
-let mark_duniverse_content_as_vendored ~duniverse_dir =
-  let open Result.O in
-  let dune_file = Fpath.(duniverse_dir / "dune") in
-  let content = Dune_file.Raw.duniverse_dune_content in
-  Logs.debug (fun l ->
-      l "Writing %a:\n %s" Styled_pp.path dune_file (String.concat ~sep:"\n" content));
-  Persist.write_lines_hum dune_file content >>= fun () ->
-  Logs.debug (fun l -> l "Successfully wrote %a" Styled_pp.path dune_file);
-  Ok ()
-
-let pull ?(trim_clone = false) ~duniverse_dir ~cache src_dep =
-  let open Result.O in
-  let open Duniverse.Deps.Source in
-  let { dir; upstream; ref = { Git.Ref.t = ref; commit }; _ } = src_dep in
-  let output_dir = Fpath.(duniverse_dir / dir) in
-  Bos.OS.Dir.delete ~must_exist:false ~recurse:true output_dir >>= fun () ->
-  Cloner.clone_to ~output_dir ~remote:upstream ~ref ~commit cache
-  |> Rresult.R.reword_error (fun (`Msg _) -> `Commit_is_gone dir)
-  >>= fun cached ->
-  Common.Logs.app (fun l ->
-      l "Pulled sources for %a.%a" Styled_pp.path output_dir Styled_pp.cached cached);
-  if trim_clone then
-    Bos.OS.Dir.delete ~must_exist:true ~recurse:true Fpath.(output_dir / ".git") >>= fun () ->
-    Bos.OS.Dir.delete ~recurse:true Fpath.(output_dir // Config.vendor_dir)
-  else Ok ()
-
-let report_commit_is_gone_repos repos =
-  let sep fmt () =
-    Format.pp_print_newline fmt ();
-    Styled_pp.header_indent fmt ();
-    Fmt_ext.(const string "  - ") fmt ()
-  in
-  let fmt_repos = Fmt_ext.(list ~sep Styled_pp.package_name) in
-  Common.Logs.app (fun l ->
-      l "The following repos could not be pulled as the commit we want is gone:%a%a" sep ()
-        fmt_repos repos);
-  Common.Logs.app (fun l ->
-      l "You should run 'duniverse update' to fix the commits associated with the tracked refs")
-
-let submodule_add ~repo ~duniverse_dir src_dep =
-  let open Result.O in
-  let open Duniverse.Deps.Source in
-  let { dir; upstream; ref = { Git.Ref.t = _ref; commit }; _ } = src_dep in
-  let remote_name = match Astring.String.cut ~sep:"." dir with Some (p, _) -> p | None -> dir in
-  let target_path = Fpath.(normalize (duniverse_dir / dir)) in
-  let frag =
-    Printf.sprintf "[submodule %S]\n  path=%s\n  url=%s" remote_name (Fpath.to_string target_path)
-      upstream
-  in
-  let cacheinfo = (160000, commit, target_path) in
-  Exec.git_update_index ~repo ~add:true ~cacheinfo () >>= fun () ->
-  Common.Logs.app (fun l -> l "Added submodule for %s." dir);
-  Ok frag
-
-let set_git_submodules ~repo ~duniverse_dir src_deps =
-  let open Result.O in
-  List.map ~f:(submodule_add ~repo ~duniverse_dir) src_deps
-  |> Result.List.fold_left ~init:[] ~f:(fun acc res ->
-         match res with
-         | Ok frag -> Ok (frag :: acc)
-         | Error (`Msg _ as err) -> Error (err :> [> `Msg of string ]))
-  >>= fun git_sm_frags ->
-  let git_sm = String.concat ~sep:"\n" git_sm_frags in
-  Bos.OS.File.write Fpath.(repo / ".gitmodules") git_sm >>= fun () ->
-  Common.Logs.app (fun l -> l "Successfully wrote gitmodules.");
-  Ok ()
-
-let pull_source_dependencies ?trim_clone ~duniverse_dir ~cache src_deps =
-  let open Result.O in
-  List.map ~f:(pull ?trim_clone ~duniverse_dir ~cache) src_deps
-  |> Result.List.fold_left ~init:[] ~f:(fun acc res ->
-         match res with
-         | Ok () -> Ok acc
-         | Error (`Commit_is_gone dir) -> Ok (dir :: acc)
-         | Error (`Msg _ as err) -> Error (err :> [> `Msg of string ]))
-  >>= function
-  | [] ->
-      let total = List.length src_deps in
-      let pp_count = Styled_pp.good Fmt_ext.int in
-      Common.Logs.app (fun l ->
-          l "Successfully pulled %a/%a repositories" pp_count total pp_count total);
-      Ok ()
-  | commit_is_gone_repos ->
-      report_commit_is_gone_repos commit_is_gone_repos;
-      Error (`Msg "Could not pull all the source dependencies")
-
 let get_cache ~no_cache = if no_cache then Ok Cloner.no_cache else Cloner.get_cache ()
 
 let run (`Yes yes) (`No_cache no_cache) (`Repo repo) (`Duniverse_repos duniverse_repos) () =
@@ -152,17 +66,12 @@ let run (`Yes yes) (`No_cache no_cache) (`Repo repo) (`Duniverse_repos duniverse
       Ok ()
   | { deps = { duniverse; _ }; config; _ } ->
       Common.filter_duniverse ~to_consider:duniverse_repos duniverse >>= fun duniverse ->
-      let sm = Duniverse.Config.(config.pull_mode = Submodules) in
       Common.Logs.app (fun l ->
           l "Using pull mode %s"
             (Sexplib.Sexp.to_string_hum Duniverse.Config.(sexp_of_pull_mode config.pull_mode)));
       check_dune_lang_version ~yes ~repo >>= fun () ->
-      let duniverse_dir = Fpath.(repo // Config.vendor_dir) in
-      Bos.OS.Dir.create duniverse_dir >>= fun _created ->
-      mark_duniverse_content_as_vendored ~duniverse_dir >>= fun () ->
       get_cache ~no_cache >>= fun cache ->
-      pull_source_dependencies ~trim_clone:(not sm) ~duniverse_dir ~cache duniverse >>= fun () ->
-      if sm then set_git_submodules ~repo ~duniverse_dir duniverse else Ok ()
+      Pull.duniverse ~cache ~pull_mode:config.Duniverse.Config.pull_mode ~repo duniverse
 
 let no_cache =
   let doc = "Run without using the duniverse global cache" in

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -33,4 +33,6 @@ let duniverse_file = Fpath.v "dune-get"
 
 let vendor_dir = Fpath.v "duniverse"
 
+let pins_dir = Fpath.v "duniverse/.pins"
+
 let duniverse_log = Fpath.v ".duniverse-log"

--- a/lib/duniverse.ml
+++ b/lib/duniverse.ml
@@ -171,6 +171,7 @@ module Config = struct
   type t = {
     version: string;
     root_packages : Types.Opam.package list;
+    pins : Types.Opam.pin list; [@default []] [@sexp_drop_default.sexp]
     pull_mode : pull_mode; [@default Source]
     opam_repo : Uri_sexp.t;
         [@default Uri.of_string Config.duniverse_opam_repo] [@sexp_drop_default.sexp]

--- a/lib/duniverse.mli
+++ b/lib/duniverse.mli
@@ -91,6 +91,7 @@ module Config : sig
   type t = {
     version: string;
     root_packages : Types.Opam.package list;
+    pins : Types.Opam.pin list;
     pull_mode : pull_mode; [@default Submodules]
     opam_repo : Uri_sexp.t;
     ocaml_compilers : string list; [@default []]

--- a/lib/opam_cmd.ml
+++ b/lib/opam_cmd.ml
@@ -134,12 +134,17 @@ let classify_package ~package ~dev_repo ~archive () =
             (kind, tag)
         | x -> (x, None) )
 
-let get_opam_depexts ~get_opam_path pkg =
-  let opam_file = get_opam_path pkg in
-  Bos.OS.File.read opam_file >>| fun opam_contents ->
-  let opam = OpamFile.OPAM.read_from_string opam_contents in
-  OpamFile.OPAM.depexts opam |>
-  List.map (fun (s, f) -> (s, OpamFilter.to_string f))
+let compute_depexts ~get_opam_path pkgs =
+  let opam_depexts_of_pkg pkg =
+    let opam_file = get_opam_path pkg in
+    Bos.OS.File.read opam_file >>| fun opam_contents ->
+    let opam = OpamFile.OPAM.read_from_string opam_contents in
+    OpamFile.OPAM.depexts opam |>
+    List.map (fun (s, f) -> (s, OpamFilter.to_string f))
+  in
+  let open Rresult.R in
+  Exec.map opam_depexts_of_pkg pkgs >>| fun depexts ->
+  List.flatten depexts |> List.sort_uniq Stdlib.compare
 
 let get_opam_info ~get_opam_path packages =
   List.map

--- a/lib/pins.ml
+++ b/lib/pins.ml
@@ -1,0 +1,73 @@
+open Astring
+open Rresult.R
+
+
+let compute_deps ~opam_entries =
+  Dune_cmd.log_invalid_packages opam_entries;
+  let get_default_branch remote = Exec.git_default_branch ~remote () in
+  Duniverse.Deps.from_opam_entries ~get_default_branch opam_entries
+
+let resolve_ref deps =
+  let resolve_ref ~upstream ~ref = Exec.git_resolve ~remote:upstream ~ref in
+  Duniverse.Deps.resolve ~resolve_ref deps
+
+let path pin =
+  Fpath.(Config.pins_dir / (pin.Types.Opam.pin ^ ".opam"))
+
+let read_from_config duniverse_file =
+  Bos.OS.File.exists duniverse_file >>= fun exists ->
+  if not exists then Ok [] else
+  Duniverse.load ~file:duniverse_file >>= fun duniverse ->
+  Ok duniverse.config.pins
+
+let to_package (pin : Types.Opam.pin) : Types.Opam.package =
+  let name = pin.pin in
+  let version = None in
+  {name; version}
+
+let to_opam_entry (pin : Types.Opam.pin) : Types.Opam.entry =
+  let name = pin.pin in
+  let package = to_package pin in
+  let dev_repo = Opam_cmd.classify_from_dev_repo ~name pin.url in
+  { package; dev_repo; tag = pin.tag; is_dune = true }
+
+let copy_opam_files ~pinned_paths deps =
+  Bos.OS.Dir.create Config.pins_dir >>= fun _created ->
+  Stdune.Result.List.iter deps
+    ~f:(fun {Duniverse.Deps.Source.dir; provided_packages; _} ->
+      Stdune.Result.List.iter provided_packages
+        ~f:(fun {Duniverse.Deps.Opam.name; _} ->
+          if String.Map.mem name pinned_paths then Ok () else
+          let opam = name ^ ".opam" in
+          let src = Fpath.(Config.vendor_dir / dir / opam |> to_string) in
+          let dst = Fpath.(Config.pins_dir / opam |> to_string) in
+          let cmd = Bos.Cmd.(v "cp" % src % dst) in (* FIXME: does this work on win? *)
+          Bos.OS.Cmd.run cmd))
+
+let remove_stale_pins ~pinned_paths pins =
+  if pins = [] then Bos.OS.Dir.delete ~recurse:true Config.pins_dir else
+  let stale =
+    String.Map.filter
+      (fun name _ -> not (List.exists (fun pin -> pin.Types.Opam.pin = name) pins))
+      pinned_paths in
+  String.Map.fold (fun _ p _ -> Bos.OS.File.delete ~must_exist:true p) stale (Ok ())
+
+let pull ~pull_mode ~repo ~pinned_paths pins =
+  let opam_entries = List.map to_opam_entry pins in
+  compute_deps ~opam_entries >>= resolve_ref >>= fun {Duniverse.Deps.duniverse; _} ->
+  let duniverse_to_pull =
+    List.filter (fun {Duniverse.Deps.Source.provided_packages; _} ->
+        List.for_all (fun {Duniverse.Deps.Opam.name; _} -> not (String.Map.mem name pinned_paths))
+          provided_packages)
+      duniverse in
+  Cloner.get_cache () >>= fun cache ->
+  Pull.duniverse ~cache ~pull_mode ~repo duniverse_to_pull >>= fun () ->
+  Ok duniverse
+
+let init ~repo ~pull_mode ~pins =
+  Opam_cmd.find_local_opam_packages Config.pins_dir >>= fun pinned_paths ->
+  remove_stale_pins ~pinned_paths pins >>= fun () ->
+  pull ~pull_mode ~repo ~pinned_paths pins >>= fun src_deps ->
+  copy_opam_files ~pinned_paths src_deps >>= fun () ->
+  Ok src_deps
+

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -87,6 +87,7 @@ let set_git_submodules ~repo ~duniverse_dir src_deps =
   Ok ()
 
 let duniverse ~cache ~pull_mode ~repo duniverse =
+  if List.is_empty duniverse then Ok () else
   let open Result.O in
   let duniverse_dir = Fpath.(repo // Config.vendor_dir) in
   Bos.OS.Dir.create duniverse_dir >>= fun _created ->

--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -1,0 +1,99 @@
+open Stdune
+
+let report_commit_is_gone_repos repos =
+  let sep fmt () =
+    Format.pp_print_newline fmt ();
+    Styled_pp.header_indent fmt ();
+    Fmt.(const string "  - ") fmt ()
+  in
+  let fmt_repos = Fmt.(list ~sep Styled_pp.package_name) in
+  Logs.app (fun l ->
+      l "The following repos could not be pulled as the commit we want is gone:%a%a" sep ()
+        fmt_repos repos);
+  Logs.app (fun l ->
+      l "You should run 'duniverse update' to fix the commits associated with the tracked refs")
+
+let pull ?(trim_clone = false) ~duniverse_dir ~cache src_dep =
+  let open Result.O in
+  let open Duniverse.Deps.Source in
+  let { dir; upstream; ref = { Git.Ref.t = ref; commit }; _ } = src_dep in
+  let output_dir = Fpath.(duniverse_dir / dir) in
+  Bos.OS.Dir.delete ~must_exist:false ~recurse:true output_dir >>= fun () ->
+  Cloner.clone_to ~output_dir ~remote:upstream ~ref ~commit cache
+  |> Rresult.R.reword_error (fun (`Msg _) -> `Commit_is_gone dir)
+  >>= fun _cached ->
+  (* Common.Logs.app (fun l ->
+      l "Pulled sources for %a.%a" Styled_pp.path output_dir Styled_pp.cached cached); *)
+  if trim_clone then
+    Bos.OS.Dir.delete ~must_exist:true ~recurse:true Fpath.(output_dir / ".git") >>= fun () ->
+    Bos.OS.Dir.delete ~recurse:true Fpath.(output_dir // Config.vendor_dir)
+  else Ok ()
+
+let pull_source_dependencies ?trim_clone ~duniverse_dir ~cache src_deps =
+  let open Result.O in
+  List.map ~f:(pull ?trim_clone ~duniverse_dir ~cache) src_deps
+  |> Result.List.fold_left ~init:[] ~f:(fun acc res ->
+         match res with
+         | Ok () -> Ok acc
+         | Error (`Commit_is_gone dir) -> Ok (dir :: acc)
+         | Error (`Msg _ as err) -> Error (err :> [> `Msg of string ]))
+  >>= function
+  | [] ->
+      let total = List.length src_deps in
+      let pp_count = Styled_pp.good Fmt.int in
+      Logs.app (fun l ->
+          l "Successfully pulled %a/%a repositories" pp_count total pp_count total);
+      Ok ()
+  | commit_is_gone_repos ->
+      report_commit_is_gone_repos commit_is_gone_repos;
+      Error (`Msg "Could not pull all the source dependencies")
+
+let mark_duniverse_content_as_vendored ~duniverse_dir =
+  let open Result.O in
+  let dune_file = Fpath.(duniverse_dir / "dune") in
+  let content = Dune_file.Raw.duniverse_dune_content in
+  Logs.debug (fun l ->
+      l "Writing %a:\n %s" Styled_pp.path dune_file (String.concat ~sep:"\n" content));
+  Persist.write_lines_hum dune_file content >>= fun () ->
+  Logs.debug (fun l -> l "Successfully wrote %a" Styled_pp.path dune_file);
+  Ok ()
+
+let submodule_add ~repo ~duniverse_dir src_dep =
+  let open Result.O in
+  let open Duniverse.Deps.Source in
+  let { dir; upstream; ref = { Git.Ref.t = _ref; commit }; _ } = src_dep in
+  let remote_name = match Astring.String.cut ~sep:"." dir with Some (p, _) -> p | None -> dir in
+  let target_path = Fpath.(normalize (duniverse_dir / dir)) in
+  let frag =
+    Printf.sprintf "[submodule %S]\n  path=%s\n  url=%s" remote_name (Fpath.to_string target_path)
+      upstream
+  in
+  let cacheinfo = (160000, commit, target_path) in
+  Exec.git_update_index ~repo ~add:true ~cacheinfo () >>= fun () ->
+  (* Common.Logs.app (fun l -> l "Added submodule for %s." dir); *)
+  Ok frag
+
+let set_git_submodules ~repo ~duniverse_dir src_deps =
+  let open Result.O in
+  List.map ~f:(submodule_add ~repo ~duniverse_dir) src_deps
+  |> Result.List.fold_left ~init:[] ~f:(fun acc res ->
+         match res with
+         | Ok frag -> Ok (frag :: acc)
+         | Error (`Msg _ as err) -> Error (err :> [> `Msg of string ]))
+  >>= fun git_sm_frags ->
+  let git_sm = String.concat ~sep:"\n" git_sm_frags in
+  Bos.OS.File.write Fpath.(repo / ".gitmodules") git_sm >>= fun () ->
+  (* Common.Logs.app (fun l -> l "Successfully wrote gitmodules."); *)
+  Ok ()
+
+let duniverse ~cache ~pull_mode ~repo duniverse =
+  let open Result.O in
+  let duniverse_dir = Fpath.(repo // Config.vendor_dir) in
+  Bos.OS.Dir.create duniverse_dir >>= fun _created ->
+  mark_duniverse_content_as_vendored ~duniverse_dir >>= fun () ->
+  let sm = pull_mode = Duniverse.Config.Submodules in
+  pull_source_dependencies ~trim_clone:(not sm) ~duniverse_dir ~cache duniverse >>= fun () ->
+  if sm then set_git_submodules ~repo ~duniverse_dir duniverse else Ok ()
+
+
+

--- a/lib/pull.mli
+++ b/lib/pull.mli
@@ -1,0 +1,10 @@
+
+val duniverse :
+  cache:Cloner.cache ->
+  pull_mode:Duniverse.Config.pull_mode ->
+  repo:Fpath.t ->
+  Duniverse.resolved Duniverse.Deps.Source.t list ->
+  (unit, [> Rresult.R.msg]) result
+(** Pulls resolved source dependencies into [Config.vendor_dir] using the provided [cache].
+    If [pull_mode] is [Duniverse.Config.Submodules], the cloned dependencies will be added as
+    git submodules to the [repo]. *)


### PR DESCRIPTION
This PR adds support for pinned packages to duniverse.

Pinned packages can be added to the `dune-get` file with `duniverse pin PACKAGE REPO`. When a pin is found in `dune-get` during `duniverse init` it will be pulled and included in the dependency resolution. An opam entry with a fixed ref is attributed to each pin and saved in `dune-get` to achieve reproducible pulls and builds.

In addition to including the pins in the dependency resolution, the opam files of the pinned packages are stored in `Config.pins_dir`. These files can be optionally changed to override build options or dependencies, for example.

## Duniverse file changes

The pinned packages are included in the `config` section of the duniverse. Here's an example:

```lisp
((config
  ((version 1) (root_packages (((name my-app))))
   (pins
    (((pin coap-server-lwt)
      (url (https://github.com/hypercollective/ocaml-coap.git)))
     ((pin coap-core)
      (url (https://github.com/hypercollective/ocaml-coap.git)))))
...
```

## duniverse pin/unpin

Two convenience commands are added to help updating the `dune-get` file:

```
$ duniverse pin coap-core git+https://github.com/hypercollective/ocaml-coap.git
==> Added pin coap-core to dune-get. You can now run duniverse init to update the dependencies.

$ duniverse unpin coap-core
==> Removed pin coap-core from dune-get. You can now run duniverse init to update the dependencies.
```

Currently these commands **do not** automatically update the dependencies. The initial motivation is that users might want to add/remove multiple pins, but I'm actually thinking about changing this to force (re)`init` after each pin/unpin.

## Notes
1. Running `duniverse init` when pins are present in the duniverse file, will pull the sources into the duniverse folder. This is needed because we need to get the opam files for the pinned packages (so that dependencies can be correctly resolved).
    - I have thought about pulling pins into a temporary folder, but honestly, I'm not sure if it matters that much.
2. The obtained opam files, after they're used for dependency resolution, are also put in `./duniverse/.pins`.
    - We want to allow users to change those files and re-run `duniverse init` to update any `depends` changes.
    - When running `duniverse init`, existing opam files in `./duniverse/.pins` will not be overwritten.
    - Manually copying opam files into `./duniverse/.pins` is **not** sufficient for `init` to work properly, they must also be present in `dune-get`.
    - If a pin is removed from `dune-get`, running `duniverse init` will remove the associated opam file.
    - Currently the pins directory is `./duniverse/.pins`. Using a hidden path is important because this way dune will not attempt to analyse the opam files and complain about duplicate packages. We should probably rename this to `./duniverse/_pins` as using hidden paths might be confusing (see https://dune.readthedocs.io/en/stable/dune-files.html#dirs-since-1-6).
3. There might be some problems if a pinned opam file has a `url.src` or `dev-repo` fields. I'll submit a commit to address this soon.
4. Even though a new field was added to `config` in `dune-get`, the change is backwards compatible. The `pins` field is optional.
5. It is assumed that pinned packages are dune-compatible. I plan on improving error reporting, in case they're not.

## Final thoughts

I recommend reading individual commits in the chronological order to understand this PR.
One particular implementation detail is the fact that pins are fetched during init as a "mini-duniverse". This is very convenient because we can benefit from existing logic to ensure fixed refs, and related pins are automatically grouped.

Also many thanks to @avsm for suggestions about how to approach this feature! 🙌  This is probably still incomplete, but I'm already using this in a private project and am planning on improving things as I run into issues.