### PR TITLE
Update dependencies (i.e. run init) when adding/removing pins.

### DIFF
--- a/cli/pin.ml
+++ b/cli/pin.ml
@@ -2,7 +2,7 @@ open Duniverse_lib
 open Rresult
 
 
-let pin (`Pin_name to_add) (`Pin_uri uri) (`Repo repo) () =
+let pin (`Pin_name pin_name) (`Pin_uri uri) (`Repo repo) () =
   let file = Fpath.(repo // Config.duniverse_file) in
   Bos.OS.File.exists file >>= fun exists ->
   if not exists then
@@ -12,25 +12,26 @@ let pin (`Pin_name to_add) (`Pin_uri uri) (`Repo repo) () =
   else
     let tag = Uri.fragment uri in
     let uri = Uri.with_fragment uri None in
-    let pin = { Types.Opam.pin = to_add; url = Some (Uri.to_string uri); tag } in
+    let pin = { Types.Opam.pin = pin_name; url = Some (Uri.to_string uri); tag } in
     Duniverse.load ~file >>= fun duniverse ->
-    if List.exists (fun pin -> pin.Types.Opam.pin = to_add) duniverse.config.pins then
+    if List.exists (fun pin -> pin.Types.Opam.pin = pin_name) duniverse.config.pins then
       R.error_msgf "Could not add pin `%s` as this package already exists in %a."
-        to_add Fpath.pp (Fpath.normalize file)
+        pin_name Fpath.pp (Fpath.normalize file)
     else
     let config = { duniverse.config with pins = pin :: duniverse.config.pins } in
     let duniverse = { duniverse with config } in
     Duniverse.save ~file duniverse >>= fun () ->
     Common.Logs.app (fun l ->
-        l "Added pin %a to %a. You can now run %a to update the dependencies."
-          Fmt.(styled `Yellow string) to_add
-          Styled_pp.path (Fpath.normalize file)
-          Fmt.(styled `Blue string)
-          "duniverse init");
-    Ok ()
+        l "Added pin %a to %a."
+          Fmt.(styled `Yellow string) pin_name
+          Styled_pp.path (Fpath.normalize file));
+    Common.Logs.app (fun l -> l "Updating dependencies...");
+    let opam_repo = duniverse.config.opam_repo in
+    let pull_mode = duniverse.config.pull_mode in
+    Init.run (`Repo repo) (`Opam_repo opam_repo) (`Pull_mode pull_mode) ()
 
 
-let unpin (`Pin_name to_remove) (`Repo repo) () =
+let unpin (`Pin_name pin_name) (`Repo repo) () =
   let file = Fpath.(repo // Config.duniverse_file) in
   Bos.OS.File.exists file >>= fun exists ->
   if not exists then
@@ -40,21 +41,22 @@ let unpin (`Pin_name to_remove) (`Repo repo) () =
   else
     Duniverse.load ~file >>= fun duniverse ->
     let pins_len = List.length duniverse.config.pins in
-    let filtered = List.filter (fun pin -> pin.Types.Opam.pin <> to_remove) duniverse.config.pins in
+    let filtered = List.filter (fun pin -> pin.Types.Opam.pin <> pin_name) duniverse.config.pins in
     if pins_len = List.length filtered then
-      R.error_msgf "Could not find pin `%s` in %a." to_remove Fpath.pp (Fpath.normalize file)
+      R.error_msgf "Could not find pin `%s` in %a." pin_name Fpath.pp (Fpath.normalize file)
     else
       let config = { duniverse.config with pins = filtered } in
       let duniverse = { duniverse with config } in
       Duniverse.save ~file duniverse >>= fun () ->
-      Bos.OS.File.delete Fpath.(Config.pins_dir / (to_remove ^ ".opam")) >>= fun () ->
+      Bos.OS.File.delete Fpath.(Config.pins_dir / (pin_name ^ ".opam")) >>= fun () ->
       Common.Logs.app (fun l ->
-          l "Removed pin %a from %a. You can now run %a to update the dependencies."
-            Fmt.(styled `Yellow string) to_remove
-            Styled_pp.path (Fpath.normalize file)
-            Fmt.(styled `Blue string)
-            "duniverse init");
-      Ok ()
+          l "Removed pin %a from %a."
+            Fmt.(styled `Yellow string) pin_name
+            Styled_pp.path (Fpath.normalize file));
+    Common.Logs.app (fun l -> l "Updating dependencies...");
+    let opam_repo = duniverse.config.opam_repo in
+    let pull_mode = duniverse.config.pull_mode in
+    Init.run (`Repo repo) (`Opam_repo opam_repo) (`Pull_mode pull_mode) ()
 
 
 open Cmdliner


### PR DESCRIPTION
Forces init on every pin change. This results in repeated dep recomputations when adding multiple pins, but saves time for the the most common case – "I just want to pin this".

This addresses the second point in https://github.com/ocamllabs/duniverse/pull/87#issuecomment-640549805.