### PR TITLE
Fix submodule pull mode bug where absolute path is used

### DIFF
--- a/lib/pull.ml
+++ b/lib/pull.ml
@@ -63,7 +63,12 @@ let submodule_add ~repo ~duniverse_dir src_dep =
   let open Duniverse.Deps.Source in
   let { dir; upstream; ref = { Git.Ref.t = _ref; commit }; _ } = src_dep in
   let remote_name = match Astring.String.cut ~sep:"." dir with Some (p, _) -> p | None -> dir in
-  let target_path = Fpath.(normalize (duniverse_dir / dir)) in
+  let target_path =
+    let submodule_dir = Fpath.(duniverse_dir / dir) in
+    match Fpath.relativize ~root:repo submodule_dir with
+    | Some path -> Fpath.normalize path
+    | None -> Fpath.normalize submodule_dir
+  in
   let frag =
     Printf.sprintf "[submodule %S]\n  path=%s\n  url=%s" remote_name (Fpath.to_string target_path)
       upstream


### PR DESCRIPTION
I haven't been testing the submodules pull mode recently but decided to give it a try today. When running pull I started seeing this error:

```
duniverse.exe: [ERROR] git -C /Users/rizo/Areas/Hyper/Code/edge-server
                         update-index --add --cacheinfo 160000
                         d18d13c83e974f939373ad6877d693253ba32966
                         /Users/rizo/Areas/Hyper/Code/edge-server/duniverse/coap.master failed. Output was:
error: Invalid path
'/Users/rizo/Areas/Hyper/Code/edge-server/duniverse/coap.master'
fatal: git update-index: --cacheinfo cannot add
/Users/rizo/Areas/Hyper/Code/edge-server/duniverse/coap.master
```

I intentionally left the real paths to show how `git update-index` is complaining about an invalid path. This seems to be because it expects a relative path, while an absolute one is used.

This path is created based on the `repo` path argument which has recently been changed from `.` to `Sys.getcwd ())` (see https://github.com/ocamllabs/duniverse/commit/86abd05baa4770f7151809593d68d65085e3faf9#diff-385ea090d5cd43c02efaddf2e252dcb9R13).

This PR addresses this by relativising the submodule directory path to the repo directory.