### PR TITLE
Update the suggested repo to add

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ DESCRIPTION
        This is a particularly convenient way of publishing CLI tools to users
        who do not need the full power of opam.
 
-       You can access the functionality directly via the monorepo-init,
-       monorepo-opam-install and monorepo-pull commands,
+       You can access the functionality directly via the monorepo-lock and
+       monorepo-pull commands,
 
        Also see https://github.com/avsm/platform for an example of a fully
        bootstrapping use of this tool.

--- a/cli/lock.ml
+++ b/cli/lock.ml
@@ -55,9 +55,10 @@ let check_repo_config ~global_state ~switch_state =
       if not dune_universe_is_configured then
         Logs.warn (fun l ->
             l
-              "The dune-universe opam-repository isn't set in the current switch. For %a to behave \
-               properly you should add it to the list of the configured repos for this switch by \
-               running:\n\
+              "The dune-universe opam-repository isn't set in the current switch. It contains dune \
+               ports for some opam packages. Note that %a will fail if not all of the project \
+               dependencies use dune as their build system. Adding this opam-repository to your \
+               current switch will help with that. If you wish to do so, run the following command:\n\
                opam repository add dune-universe %s"
               Fmt.(styled `Bold string)
               "opam monorepo lock" Config.duniverse_opam_repo))

--- a/lib/config.ml
+++ b/lib/config.ml
@@ -27,7 +27,7 @@ let base_packages =
     "ocaml-variants";
   ]
 
-let duniverse_opam_repo = "git+https://github.com/dune-universe/opam-repository.git#duniverse"
+let duniverse_opam_repo = "git+https://github.com/dune-universe/opam-overlays.git"
 
 let dune_get = Fpath.v "dune-get"
 


### PR DESCRIPTION
@TheLortex recently noticed this suggestion was not up to date. The new plugin doesn't require a single repo with dune packages only and it therefore makes more sense to suggest adding the overlays to the current switch configuration. 